### PR TITLE
Exclude another Unity folder: `${currentDepotPath}_BackUpThisFolder_ButDontShipItWithYourGame`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,6 @@ Note that the `default` branch [has been observed to not work](https://github.co
 Certain file or folder patterns are excluded from the upload to Steam as they're unsafe to ship to players:
 
 - `*.pdb` - symbols files
-- `${depotPath}_BurstDebugInformation_DoNotShip` folders for each uploaded depot (e.g. `StandaloneWindows64_BurstDebugInformation_DoNotShip`) - a folder that Unity includes in builds with debugging or other information that isn't intended to be sent to players
+- Folders that Unity includes in builds with debugging or other information that isn't intended to be sent to players:
+    - `*_BurstDebugInformation_DoNotShip`
+    - `*_BackUpThisFolder_ButDontShipItWithYourGame`

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -27,7 +27,8 @@ until [ $i -gt 9 ]; do
     "recursive" "1"
   }
   "FileExclusion" "*.pdb"
-  "FileExclusion" "$currentDepotPath/${currentDepotPath}_BurstDebugInformation_DoNotShip*"
+  "FileExclusion" "**/*_BurstDebugInformation_DoNotShip*"
+  "FileExclusion" "**/*_BackUpThisFolder_ButDontShipItWithYourGame*"
 }
 EOF
 


### PR DESCRIPTION
#### Changes

- Exclude the `${currentDepotPath}_BackUpThisFolder_ButDontShipItWithYourGame` directory that was mentioned after #22 was merged

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated)
- [x] Tests (not needed)
