### PR TITLE
Test app/depot configurable with secrets and add DLC support (doesn't use appId + 1 for first depot)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
           configVdf: ${{ secrets.STEAM_CONFIG_VDF}}
           ssfnFileName: ${{ secrets.STEAM_SSFN_FILE_NAME }}
           ssfnFileContents: ${{ secrets.STEAM_SSFN_FILE_CONTENTS }}
-          appId: 1234560
+          appId: ${{ secrets.TEST_APP_ID }}
+          firstDepotIdOverride: ${{ secrets.TEST_FIRST_DEPOT_ID_OVERRIDE }}
           buildDescription: v0.0.1
           rootPath: build
           depot1Path: StandaloneWindows64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  checkEnv:
+    name: Check Env 🔎
+    runs-on: ubuntu-latest
+    outputs:
+      usernameExists: ${{ steps.checkUsername.outputs.usernameExists }}
+    steps:
+      - id: checkUsername
+        env:
+          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+        if: env.STEAM_USERNAME != ''
+        run: echo "::set-output name=usernameExists::true"
+
   testDeploy:
     name: Deploy to Steam ☁
     runs-on: ubuntu-latest
+
+    # Only run tests if secrets are available (e.g. not from PRs from forked repos)
+    needs: [checkEnv]
+    if: needs.checkEnv.outputs.usernameExists == 'true'
+
     steps:
       - uses: actions/checkout@v2
       - run: |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ The relative path following your root path for the files to be included in this 
 
 If your appId is 125000 then the depots 125001 ... 125009 will be assumed.
 
+#### firstDepotId
+
+You can use this to override the ID of the first depot in case the IDs do not start as described in depot[X]Path (e.g. for DLCs).
+
+If your firstDepotId is 125000 then, regardless of the used appId, the depots 125000 ... 125008 will be assumed.
+
 _(feel free to contribute if you have a more complex use case!)_
 
 #### releaseBranch

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
     required: true
     default: ''
     description: 'The app id within steam partner network.'
+  firstDepotIdOverride:
+    required: false
+    description: 'An optional override to specify the ID of the first depot instead of using the app ID plus one.'
   buildDescription:
     required: false
     description: 'Description for this build.'
@@ -81,6 +84,7 @@ runs:
         ssfnFileName: ${{ inputs.ssfnFileName }}
         ssfnFileContents: ${{ inputs.ssfnFileContents }}
         appId: ${{ inputs.appId }}
+        firstDepotIdOverride: ${{ inputs.firstDepotIdOverride }}
         buildDescription: ${{ inputs.buildDescription }}
         rootPath: ${{ inputs.rootPath }}
         depot1Path: ${{ inputs.depot1Path }}

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -6,12 +6,21 @@ echo "#   Generating Depot Manifests  #"
 echo "#################################"
 echo ""
 
+if [ -n "$firstDepotIdOverride" ]; then
+  firstDepotId=$firstDepotIdOverride
+else
+  # The first depot ID of a standard Steam app is the app's ID plus one
+  firstDepotId=$((appId + 1))
+fi
+
 i=1;
 export DEPOTS="\n  "
 until [ $i -gt 9 ]; do
   eval "currentDepotPath=\$depot${i}Path"
   if [ -n "$currentDepotPath" ]; then
-    currentDepot=$((appId+i))
+    # depot1Path uses firstDepotId, depot2Path uses firstDepotId + 1, depot3Path uses firstDepotId + 2...
+    currentDepot=$((firstDepotId + i - 1))
+
     echo ""
     echo "Adding depot${currentDepot}.vdf ..."
     echo ""


### PR DESCRIPTION
#### Changes

- firstDepotIdOverride input added
    - This is needed to support DLCs on Steam which don't follow the `appId + 1` pattern
    - Added this now because the current suggestion in #18 is to use a DLC to get tests passing
- Add `$TEST_APP_ID` and `$TEST_FIRST_DEPOT_ID_OVERRIDE` secrets so the test app/depot can be configured without needing to change code

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated)
- [x] Tests (updated)
