### PR TITLE
Revert "chore: add manual trigger for versioning workflow"

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,7 +1,6 @@
 name: Versioning
 
 on:
-  workflow_dispatch:
   release:
     types: [published, edited]
 


### PR DESCRIPTION
Reverts game-ci/steam-deploy#30

Manual workflow output: `This action should only be used in a release context.`