### PR TITLE
Fix input name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ The relative path following your root path for the files to be included in this 
 
 If your appId is 125000 then the depots 125001 ... 125009 will be assumed.
 
-#### firstDepotId
+#### firstDepotIdOverride
 
 You can use this to override the ID of the first depot in case the IDs do not start as described in depot[X]Path (e.g. for DLCs).
 
-If your firstDepotId is 125000 then, regardless of the used appId, the depots 125000 ... 125008 will be assumed.
+If your firstDepotIdOverride is 125000 then, regardless of the used appId, the depots 125000 ... 125008 will be assumed.
 
 _(feel free to contribute if you have a more complex use case!)_
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If your appId is 125000 then the depots 125001 ... 125009 will be assumed.
 
 You can use this to override the ID of the first depot in case the IDs do not start as described in depot[X]Path (e.g. for DLCs).
 
-If your firstDepotIdOverride is 125000 then, regardless of the used appId, the depots 125000 ... 125008 will be assumed.
+If your firstDepotId is 125000 then, regardless of the used appId, the depots 125000 ... 125008 will be assumed.
 
 _(feel free to contribute if you have a more complex use case!)_
 


### PR DESCRIPTION
#### Changes

After running this action I got the error:
```
Unexpected input(s) 'firstDepotId', valid inputs are ['username', 'password', 'configVdf', 'ssfnFileName', 'ssfnFileContents', 'appId', 'firstDepotIdOverride', 'buildDescription', 'rootPath', 'depot1Path', 'depot2Path', 'depot3Path', 'depot4Path', 'depot5Path', 'depot6Path', 'depot7Path', 'depot8Path', 'depot9Path', 'releaseBranch']
```
...it looks like the input parameter listed on the README isn't correct 🤔

#### Checklist

<!-- please check all items and add your own -->

- [X] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)
