### PR TITLE
Fix Linux issues caused by using outdated setup-steamcmd workflow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
   using: "composite"
   steps:
     - id: setup-steamcmd
-      uses: CyberAndrii/setup-steamcmd@v1.1.1
+      uses: CyberAndrii/setup-steamcmd@v1
     - id: steam-deploy
       env:
         STEAM_HOME: ${{ steps.setup-steamcmd.outputs.directory }}


### PR DESCRIPTION
#### Changes

Currently steam-deploy fails to run on a Linux action because v1.1.1 of the `setup-steamcmd` workflow tries to install `lib32gcc1` which doesn't exist anymore. This was fixed in v1.1.2.

This PR makes sure that steam-deploy always uses the latest bug fixes of `setup-steamcmd` v1.X.X by changing the version number from `@v1.1.1` to `@v1`. If this is an issue, I can also just update the version to `@v1.1.2` explicitly. However, that would require another PR then if issues arise in the future.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)
