### PR TITLE
Replace deprecated set-output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         if: env.STEAM_USERNAME != ''
-        run: echo "::set-output name=usernameExists::true"
+        run: echo "usernameExists=true" >> $GITHUB_OUTPUT
 
   testDeploy:
     name: Deploy to Steam ☁

--- a/action.yml
+++ b/action.yml
@@ -101,5 +101,5 @@ runs:
       run: |
         chmod +x $GITHUB_ACTION_PATH/steam_deploy.sh
         $GITHUB_ACTION_PATH/steam_deploy.sh
-        echo "::set-output name=manifest::$(pwd)/manifest.vdf"
+        echo "manifest=$(pwd)/manifest.vdf" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
The command set-output is now deprecated:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Replaced the all set-output with the new method.
