### PR TITLE
Refactor for steam MFA changes #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,8 @@ jobs:
     steps:
       - uses: game-ci/steam-deploy@v2
         with:
-          username: ${{ secrets.STEAM_USERNAME }}
-          password: ${{ secrets.STEAM_PASSWORD }}
-          configVdf: ${{ secrets.STEAM_CONFIG_VDF}}
-          ssfnFileName: ${{ secrets.STEAM_SSFN_FILE_NAME }}
-          ssfnFileContents: ${{ secrets.STEAM_SSFN_FILE_CONTENTS }}
+          username: ${{ secrets.STEAM_USERNAME }}          
+          configVdf: ${{ secrets.STEAM_CONFIG_VDF}}          
           appId: 1234560
           buildDescription: v1.2.3
           rootPath: build
@@ -66,8 +63,7 @@ jobs:
           shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
       - uses: game-ci/steam-deploy@v2
         with:
-          username: ${{ secrets.STEAM_USERNAME }}
-          password: ${{ secrets.STEAM_PASSWORD }}
+          username: ${{ secrets.STEAM_USERNAME }}          
           totp: ${{ steps.steam-totp.outputs.code }}
           appId: 1234560
           buildDescription: v1.2.3
@@ -82,10 +78,6 @@ jobs:
 #### username
 
 The username of the Steam Build Account that you created in setup step 1.
-
-#### password
-
-The password of the Steam Build Account that you created in setup step 1.
 
 #### totp
 

--- a/README.md
+++ b/README.md
@@ -81,20 +81,18 @@ The username of the Steam Build Account that you created in setup step 1.
 
 #### totp
 
-Deploying to Steam using TOTP. If this is not passed, `configVdf`, `ssfnFileName`, and `ssfnFileContents` are required.
+Deploying to Steam using TOTP. If this is not passed, `configVdf` is required.
 
-#### configVdf, ssfnFileName, and ssfnFileContents
+#### configVdf
 
 Deploying to Steam requires using Multi-Factor Authentication (MFA) through Steam Guard unless `totp` is passed.
 This means that simply using username and password isn't enough to authenticate with Steam. 
-However, it is possible to go through the MFA process only once by setting up GitHub Secrets for configVdf, ssfnFileName, and ssfnFileContents with these steps:
+However, it is possible to go through the MFA process only once by setting up GitHub Secrets for configVdf with these steps:
 1. Install [Valve's offical steamcmd](https://partner.steamgames.com/doc/sdk/uploading#1) on your local machine. All following steps will also be done on your local machine.
 1. Try to login with `steamcmd +login <username> <password> +quit`, which may prompt for the MFA code. If so, type in the MFA code that was emailed to your builder account's email address.
-1. Validate that the MFA process is complete by running `steamcmd +login <username> <password> +quit` again. It should not ask for the MFA code again.
+1. Validate that the MFA process is complete by running `steamcmd +login <username> +quit` again. It should not ask for the MFA code again.
 1. The folder from which you run `steamcmd` will now contain an updated `config/config.vdf` file. Use `cat config/config.vdf | base64 > config_base64.txt` to encode the file. Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
-1. Find the SSFN file, depending on your platform. **Windows**: The `steamcmd` folder will also contain two files of which the names look like `ssfn<numbers>`. **One of them is a hidden file**. [Find that hidden file](https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5) and use that hidden file as the correct SSFN file for the following steps. **Linux**: The SSFN file will be in the `steamcmd` folder. **Mac**: The SSFN will be at `~/Library/Application\ Support/Steam/`.
-1. Copy the name of the SSFN file to a GitHub Secret `STEAM_SSFN_FILE_NAME`.
-1. Use `cat <ssfnFileName> | base64 > ssfn_base64.txt` to encode the contents of the SSFN file. Copy the encoded contents inside `ssfn_base64.txt` to a GitHub Secret called `STEAM_SSFN_FILE_CONTENTS`.
+1. `If:` when running the action you recieve another MFA code via email, run `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf` encoding and replace secret `STEAM_CONFIG_VDF` with its contents.
 
 #### appId
 

--- a/action.yml
+++ b/action.yml
@@ -5,23 +5,13 @@ inputs:
   username:
     required: true
     default: ''
-    description: 'The username of your builder account.'
-  password:
-    required: true
-    default: ''
-    description: 'The password of your builder account.'
+    description: 'The username of your builder account.'  
   totp:
     required: false
     description: 'The TOTP to use for login. If set, `configVdf`, `ssfnFileName`, and `ssfnFileContents` will be ignored.'
   configVdf:
     required: false
-    description: 'The contents of STEAM_HOME/config/config.vdf. Required if `totp` is not set.'
-  ssfnFileName:
-    required: false
-    description: 'The basename of the STEAM_HOME/ssfn file. Required if `totp` is not set.'
-  ssfnFileContents:
-    required: false
-    description: 'The contents of the file at STEAM_HOME/ssfnFileName. Required if `totp` is not set.'
+    description: 'The contents of STEAM_HOME/config/config.vdf. Required if `totp` is not set.'  
   appId:
     required: true
     default: ''

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -89,8 +89,12 @@ if [ -n "$steam_totp" ]; then
   echo "#################################"
   echo ""
 else
-  if [ ! -n "$configVdf" ] || [ ! -n "$ssfnFileName" ] || [ ! -n "$ssfnFileContents" ]; then
-    echo "MFA inputs are missing or incomplete! Cannot proceed."
+  #if [ ! -n "$configVdf" ] || [ ! -n "$ssfnFileName" ] || [ ! -n "$ssfnFileContents" ]; then
+  #  echo "MFA inputs are missing or incomplete! Cannot proceed."
+  #  exit 1
+  #fi
+  if [ ! -n "$configVdf" ]; then
+    echo "Config VDF input is missing or incomplete! Cannot proceed."
     exit 1
   fi
 
@@ -110,9 +114,9 @@ else
   echo "$configVdf" | base64 -d > "$steamdir/config/config.vdf"
   chmod 777 "$steamdir/config/config.vdf"
 
-  echo "Copying $steamdir/ssfn..."
-  echo "$ssfnFileContents" | base64 -d > "$steamdir/$ssfnFileName"
-  chmod 777 "$steamdir/$ssfnFileName"
+  #echo "Copying $steamdir/ssfn..."
+  #echo "$ssfnFileContents" | base64 -d > "$steamdir/$ssfnFileName"
+  #chmod 777 "$steamdir/$ssfnFileName"
 
   echo "Finished Copying SteamGuard Files!"
   echo ""

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -128,7 +128,8 @@ echo "#        Test login             #"
 echo "#################################"
 echo ""
 
-steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" "$steam_password" +quit;
+#steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" "$steam_password" +quit;
+steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +quit;
 
 ret=$?
 if [ $ret -eq 0 ]; then
@@ -154,7 +155,8 @@ echo "#        Uploading build        #"
 echo "#################################"
 echo ""
 
-steamcmd +login "$steam_username" "$steam_password" +run_app_build "$manifest_path" +quit || (
+#steamcmd +login "$steam_username" "$steam_password" +run_app_build "$manifest_path" +quit || (
+steamcmd +login "$steam_username" +run_app_build "$manifest_path" +quit || (
     echo ""
     echo "#################################"
     echo "#             Errors            #"

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -88,11 +88,7 @@ if [ -n "$steam_totp" ]; then
   echo "#     Using SteamGuard TOTP     #"
   echo "#################################"
   echo ""
-else
-  #if [ ! -n "$configVdf" ] || [ ! -n "$ssfnFileName" ] || [ ! -n "$ssfnFileContents" ]; then
-  #  echo "MFA inputs are missing or incomplete! Cannot proceed."
-  #  exit 1
-  #fi
+else  
   if [ ! -n "$configVdf" ]; then
     echo "Config VDF input is missing or incomplete! Cannot proceed."
     exit 1
@@ -114,10 +110,6 @@ else
   echo "$configVdf" | base64 -d > "$steamdir/config/config.vdf"
   chmod 777 "$steamdir/config/config.vdf"
 
-  #echo "Copying $steamdir/ssfn..."
-  #echo "$ssfnFileContents" | base64 -d > "$steamdir/$ssfnFileName"
-  #chmod 777 "$steamdir/$ssfnFileName"
-
   echo "Finished Copying SteamGuard Files!"
   echo ""
 fi
@@ -128,7 +120,6 @@ echo "#        Test login             #"
 echo "#################################"
 echo ""
 
-#steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" "$steam_password" +quit;
 steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +quit;
 
 ret=$?
@@ -155,7 +146,6 @@ echo "#        Uploading build        #"
 echo "#################################"
 echo ""
 
-#steamcmd +login "$steam_username" "$steam_password" +run_app_build "$manifest_path" +quit || (
 steamcmd +login "$steam_username" +run_app_build "$manifest_path" +quit || (
     echo ""
     echo "#################################"


### PR DESCRIPTION
Refactor for #56 

Steam changed its MFA behavior recently. `ssfn*` files appear to be no longer relevant. And supplying passwords in the action script has been noted as causing a steam MFA regression where it will invalidate prior MFA approvals.

This PR makes the required adjustments to match current steam MFA behavior 

#### Changes

- Removes the need for the `ssfn*` files
- Removes the need to supply a password 
- Updates instructions to match new Steam MFA behavior
