### PR TITLE
Clarify the builder account also needs app access

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This action assumes you are registered as a [partner](https://partner.steamgames
 
 #### 1. Create a Steam Build Account
 
-Create a specialised builder account that only has access to `Edit App Metadata` and `Publish App Changes To Steam`.
+Create a specialised builder account that only has access to `Edit App Metadata` and `Publish App Changes To Steam`,
+and permissions to edit your specific app.
 
 https://partner.steamgames.com/doc/sdk/uploading#Build_Account
 


### PR DESCRIPTION
#### Changes

- Minor change to README to make it clearer the builder account _also_ needs app access granted, not just the permissions

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [n/a] Tests (added, updated or not needed)
