### PR TITLE
Switch Dockerfile base back to latest and update Steam directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM steamcmd/steamcmd:ubuntu-22
+FROM steamcmd/steamcmd:latest
 COPY steam_deploy.sh /root/steam_deploy.sh
 ENTRYPOINT ["/root/steam_deploy.sh"]

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-steamdir=${STEAM_HOME:-$HOME/Steam}
+steamdir=${STEAM_HOME:-$HOME/.steam/root}
 # this is relative to the action
 contentroot=$(pwd)/$rootPath
 


### PR DESCRIPTION
This fixes https://github.com/game-ci/steam-deploy/issues/62 by updating the root directory for the steam installation to match the new ubuntu-24 based image. The fix made in https://github.com/game-ci/steam-deploy/pull/69 did not solve the problem described in  https://github.com/game-ci/steam-deploy/issues/62 for me, but this change has.

Old Ubuntu 22 based image directory structure:
![image](https://github.com/game-ci/steam-deploy/assets/6956181/05c3d077-03ce-4f79-8d3b-de7cdc30dfa2)

New Ubuntu 24 based image directory structure:
![image](https://github.com/game-ci/steam-deploy/assets/6956181/38874936-5a71-4eab-8ea2-a7dfa594ec76)

#### Changes

- Update base image to use steamcmd/steamcmd:latest
- Change steamdir to default to the new `~/.steam/root` directory.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
