### PR TITLE
Add support for InstallScripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
           buildDescription: v1.2.3
           rootPath: build
           depot1Path: StandaloneWindows64
+          depot1InstallScriptPath: StandaloneWindows64/install_script.vdf
           depot2Path: StandaloneLinux64
           releaseBranch: prerelease
 ```

--- a/action.yml
+++ b/action.yml
@@ -28,30 +28,57 @@ inputs:
   depot1Path:
     required: false
     description: 'The path to depot1.'
+  depot1InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot1.'
   depot2Path:
     required: false
     description: 'The path to depot2.'
+  depot2InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot2.'
   depot3Path:
     required: false
     description: 'The path to depot3.'
+  depot3InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot3.'
   depot4Path:
     required: false
     description: 'The path to depot4.'
+  depot4InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot4.'
   depot5Path:
     required: false
     description: 'The path to depot5.'
+  depot5InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot5.'
   depot6Path:
     required: false
     description: 'The path to depot6.'
+  depot6InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot6.'
   depot7Path:
     required: false
     description: 'The path to depot7.'
+  depot7InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot7.'
   depot8Path:
     required: false
     description: 'The path to depot8.'
+  depot8InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot8.'
   depot9Path:
     required: false
     description: 'The path to depot9.'
+  depot9InstallScriptPath:
+    required: false
+    description: 'The path to the install script for depot9.'
   releaseBranch:
     required: false
     description: 'The branch within steam that this build will be automatically put live on.'
@@ -70,12 +97,21 @@ runs:
     buildDescription: ${{ inputs.buildDescription }}
     rootPath: ${{ inputs.rootPath }}
     depot1Path: ${{ inputs.depot1Path }}
+    depot1InstallScriptPath: ${{ inputs.depot1InstallScriptPath }}
     depot2Path: ${{ inputs.depot2Path }}
+    depot2InstallScriptPath: ${{ inputs.depot2InstallScriptPath }}
     depot3Path: ${{ inputs.depot3Path }}
+    depot3InstallScriptPath: ${{ inputs.depot3InstallScriptPath }}
     depot4Path: ${{ inputs.depot4Path }}
+    depot4InstallScriptPath: ${{ inputs.depot4InstallScriptPath }}
     depot5Path: ${{ inputs.depot5Path }}
+    depot5InstallScriptPath: ${{ inputs.depot5InstallScriptPath }}
     depot6Path: ${{ inputs.depot6Path }}
+    depot6InstallScriptPath: ${{ inputs.depot6InstallScriptPath }}
     depot7Path: ${{ inputs.depot7Path }}
+    depot7InstallScriptPath: ${{ inputs.depot7InstallScriptPath }}
     depot8Path: ${{ inputs.depot8Path }}
+    depot8InstallScriptPath: ${{ inputs.depot8InstallScriptPath }}
     depot9Path: ${{ inputs.depot9Path }}
+    depot9InstallScriptPath: ${{ inputs.depot9InstallScriptPath }}
     releaseBranch: ${{ inputs.releaseBranch }}

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -27,14 +27,26 @@ i=1;
 export DEPOTS="\n  "
 until [ $i -gt 9 ]; do
   eval "currentDepotPath=\$depot${i}Path"
+  eval "currentDepotInstallScriptPath=\$depot${i}InstallScriptPath"
   if [ -n "$currentDepotPath" ]; then
     # depot1Path uses firstDepotId, depot2Path uses firstDepotId + 1, depot3Path uses firstDepotId + 2...
     currentDepot=$((firstDepotId + i - 1))
+
+    # If the depot has an install script, add it to the depot manifest
+    if [ -n "${currentDepotInstallScriptPath:-}" ]; then
+      echo ""
+      echo "Adding install script for depot ${currentDepot}..."
+      echo ""
+      installScriptDirective="\"InstallScript\" \"${currentDepotInstallScriptPath}\""
+    else
+      installScriptDirective=""
+    fi
 
     echo ""
     echo "Adding depot${currentDepot}.vdf ..."
     echo ""
     export DEPOTS="$DEPOTS  \"$currentDepot\" \"depot${currentDepot}.vdf\"\n  "
+
     cat << EOF > "depot${currentDepot}.vdf"
 "DepotBuildConfig"
 {
@@ -48,6 +60,8 @@ until [ $i -gt 9 ]; do
   "FileExclusion" "*.pdb"
   "FileExclusion" "**/*_BurstDebugInformation_DoNotShip*"
   "FileExclusion" "**/*_BackUpThisFolder_ButDontShipItWithYourGame*"
+
+  $installScriptDirective
 }
 EOF
 
@@ -88,7 +102,7 @@ if [ -n "$steam_totp" ]; then
   echo "#     Using SteamGuard TOTP     #"
   echo "#################################"
   echo ""
-else  
+else
   if [ ! -n "$configVdf" ]; then
     echo "Config VDF input is missing or incomplete! Cannot proceed."
     exit 1


### PR DESCRIPTION
#### Reason
[InstallScripts](https://partner.steamgames.com/doc/sdk/installscripts) are useful for setting up environment variables, running processes during installation, and cleaning up files upon uninstallation, thereby enhancing the overall user experience.

#### Changes

- Adds support for [InstallScripts](https://partner.steamgames.com/doc/sdk/installscripts)

[InstallScripts](https://partner.steamgames.com/doc/sdk/installscripts) can now be _optionally_ configured by setting the `depot[id]InstallScriptPath` variable.


#### Example
```yaml
jobs:
  deployToSteam:
    runs-on: ubuntu-latest
    steps:
      - uses: game-ci/steam-deploy@v3
        with:
          username: ${{ secrets.STEAM_USERNAME }}          
          configVdf: ${{ secrets.STEAM_CONFIG_VDF}}          
          appId: 1234560
          buildDescription: v1.2.3
          rootPath: build
          depot1Path: StandaloneWindows64
          depot1InstallScriptPath: StandaloneWindows64/install_script.vdf
          depot2Path: StandaloneLinux64
          releaseBranch: prerelease
```


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
