### PR TITLE
add option to keep debug symbols for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,15 @@ The branch within steam that this build will be automatically put live on.
 
 Note that the `default` branch [has been observed to not work](https://github.com/game-ci/steam-deploy/issues/19) as a release branch, presumably because it is potentially dangerous.
 
+#### debugBranch
+
+If set to true, do not exclude debug files from the upload.
+
 ## Other Notes
 
 #### Excluded Files / Folders
 
-Certain file or folder patterns are excluded from the upload to Steam as they're unsafe to ship to players:
+Certain file or folder patterns are excluded from the upload to Steam as they're unsafe to ship to players, unless debugBranch is set to true:
 
 - `*.pdb` - symbols files
 - Folders that Unity includes in builds with debugging or other information that isn't intended to be sent to players:

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,10 @@ inputs:
   releaseBranch:
     required: false
     description: 'The branch within steam that this build will be automatically put live on.'
+  debugBranch:
+    required: false
+    description: 'If set to true, include debug symbols and directories in the upload'
+    default: false
 outputs:
   manifest:
     description: "The path to the generated manifest.vdf"
@@ -115,3 +119,4 @@ runs:
     depot9Path: ${{ inputs.depot9Path }}
     depot9InstallScriptPath: ${{ inputs.depot9InstallScriptPath }}
     releaseBranch: ${{ inputs.releaseBranch }}
+    debugBranch: ${{ inputs.debugBranch }}

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -41,6 +41,11 @@ until [ $i -gt 9 ]; do
     else
       installScriptDirective=""
     fi
+    if [ "${debugBranch}" = "true" ]; then
+      debugExcludes=""
+    else
+      debugExcludes='"FileExclusion" "*.pdb"\n  "FileExclusion" "**/*_BurstDebugInformation_DoNotShip*"\n  "FileExclusion" "**/*_BackUpThisFolder_ButDontShipItWithYourGame*"'
+    fi
 
     echo ""
     echo "Adding depot${currentDepot}.vdf ..."
@@ -57,9 +62,8 @@ until [ $i -gt 9 ]; do
     "DepotPath" "."
     "recursive" "1"
   }
-  "FileExclusion" "*.pdb"
-  "FileExclusion" "**/*_BurstDebugInformation_DoNotShip*"
-  "FileExclusion" "**/*_BackUpThisFolder_ButDontShipItWithYourGame*"
+  $(echo "$debugExcludes" |sed 's/\\n/\
+/g')
 
   $installScriptDirective
 }


### PR DESCRIPTION
#### Changes

- adds an input to allow to keep pdb files to be able to publish debug builds to steam

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option "debugBranch" that enables the upload of debug files if set to true.
	- Updated deployment documentation and configuration parameters to clarify when debug files are included.
	- Added conditional logic to dynamically adjust file exclusions during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->