### PR TITLE
Fixed missing totp parameter

### DIFF
--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -165,7 +165,8 @@ echo "#################################"
 echo ""
 
 if [ "$steam_totp" != "INVALID" ]; then
-  steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +run_app_build "$manifest_path" +quit || (
+    echo "Using TOTP for login"
+    steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +run_app_build "$manifest_path" +quit || (
     echo ""
     echo "#################################"
     echo "#             Errors            #"
@@ -213,6 +214,7 @@ if [ "$steam_totp" != "INVALID" ]; then
     exit 1
   )
 else
+    echo "Using standard login"
     steamcmd +login "$steam_username" +run_app_build "$manifest_path" +quit || (
     echo ""
     echo "#################################"

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -164,12 +164,8 @@ echo "#        Uploading build        #"
 echo "#################################"
 echo ""
 
-    steam_login_args="+login "$steam_username""
-    if [ "$steam_totp" != "INVALID" ]; then
-      steam_login_args="+set_steam_guard_code "$steam_totp" $steam_login_args"
-    fi
-
-    steamcmd $steam_login_args +run_app_build "$manifest_path" +quit || (
+if [ "$steam_totp" != "INVALID" ]; then
+  steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +run_app_build "$manifest_path" +quit || (
     echo ""
     echo "#################################"
     echo "#             Errors            #"
@@ -216,5 +212,54 @@ echo ""
 
     exit 1
   )
+else
+    steamcmd +login "$steam_username" +run_app_build "$manifest_path" +quit || (
+    echo ""
+    echo "#################################"
+    echo "#             Errors            #"
+    echo "#################################"
+    echo ""
+    echo "Listing current folder and rootpath"
+    echo ""
+    ls -alh
+    echo ""
+    ls -alh "$rootPath" || true
+    echo ""
+    echo "Listing logs folder:"
+    echo ""
+    ls -Ralph "$steamdir/logs/"
+
+    for f in "$steamdir"/logs/*; do
+      if [ -e "$f" ]; then
+        echo "######## $f"
+        cat "$f"
+        echo
+      fi
+    done
+
+    echo ""
+    echo "Displaying error log"
+    echo ""
+    cat "$steamdir/logs/stderr.txt"
+    echo ""
+    echo "Displaying bootstrapper log"
+    echo ""
+    cat "$steamdir/logs/bootstrap_log.txt"
+    echo ""
+    echo "#################################"
+    echo "#             Output            #"
+    echo "#################################"
+    echo ""
+    ls -Ralph BuildOutput
+
+    for f in BuildOutput/*.log; do
+      echo "######## $f"
+      cat "$f"
+      echo
+    done
+
+    exit 1
+  )
+fi
 
 echo "manifest=${manifest_path}" >> $GITHUB_OUTPUT

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -132,31 +132,31 @@ else
   echo ""
 fi
 
-echo ""
-echo "#################################"
-echo "#        Test login             #"
-echo "#################################"
-echo ""
+# echo ""
+# echo "#################################"
+# echo "#        Test login             #"
+# echo "#################################"
+# echo ""
 
-steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +quit;
+# steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +quit;
 
-ret=$?
-if [ $ret -eq 0 ]; then
-    echo ""
-    echo "#################################"
-    echo "#        Successful login       #"
-    echo "#################################"
-    echo ""
-else
-      echo ""
-      echo "#################################"
-      echo "#        FAILED login           #"
-      echo "#################################"
-      echo ""
-      echo "Exit code: $ret"
+# ret=$?
+# if [ $ret -eq 0 ]; then
+#     echo ""
+#     echo "#################################"
+#     echo "#        Successful login       #"
+#     echo "#################################"
+#     echo ""
+# else
+#       echo ""
+#       echo "#################################"
+#       echo "#        FAILED login           #"
+#       echo "#################################"
+#       echo ""
+#       echo "Exit code: $ret"
 
-      exit $ret
-fi
+#       exit $ret
+# fi
 
 echo ""
 echo "#################################"

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -132,31 +132,34 @@ else
   echo ""
 fi
 
-# echo ""
-# echo "#################################"
-# echo "#        Test login             #"
-# echo "#################################"
-# echo ""
+# Only run test login if not using TOTP (which is marked as INVALID)
+if [ "$steam_totp" == "INVALID" ]; then
+  echo ""
+  echo "#################################"
+  echo "#        Test login             #"
+  echo "#################################"
+  echo ""
 
-# steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +quit;
+  steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +quit;
 
-# ret=$?
-# if [ $ret -eq 0 ]; then
-#     echo ""
-#     echo "#################################"
-#     echo "#        Successful login       #"
-#     echo "#################################"
-#     echo ""
-# else
-#       echo ""
-#       echo "#################################"
-#       echo "#        FAILED login           #"
-#       echo "#################################"
-#       echo ""
-#       echo "Exit code: $ret"
+  ret=$?
+  if [ $ret -eq 0 ]; then
+      echo ""
+      echo "#################################"
+      echo "#        Successful login       #"
+      echo "#################################"
+      echo ""
+  else
+        echo ""
+        echo "#################################"
+        echo "#        FAILED login           #"
+        echo "#################################"
+        echo ""
+        echo "Exit code: $ret"
 
-#       exit $ret
-# fi
+        exit $ret
+  fi
+fi
 
 echo ""
 echo "#################################"

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -164,7 +164,12 @@ echo "#        Uploading build        #"
 echo "#################################"
 echo ""
 
-steamcmd +login "$steam_username" +run_app_build "$manifest_path" +quit || (
+    steam_login_args="+login "$steam_username""
+    if [ "$steam_totp" != "INVALID" ]; then
+      steam_login_args="+set_steam_guard_code "$steam_totp" $steam_login_args"
+    fi
+
+    steamcmd $steam_login_args +run_app_build "$manifest_path" +quit || (
     echo ""
     echo "#################################"
     echo "#             Errors            #"


### PR DESCRIPTION
#### Changes

steam-deploy supports totp, but the script only checks for the test login. The actual upload command then doesn't utilize the neccessary +set_steam_guard_code parameter. This change adds that.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the login process for Steam deployments, allowing for dynamic authentication based on the validity of security credentials. Improved error handling ensures detailed logs and outputs are consistently available during login attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->