### PR TITLE
Add password input

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ jobs:
 
 The username of the Steam Build Account that you created in setup step 1.
 
+#### password
+
+The password of the Steam Build Account. Both this and `totp` are required together, see below.
+
 #### totp
 
 Deploying to Steam using TOTP. If this is not passed, `configVdf` is required.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
     required: true
     default: ''
     description: 'The username of your builder account.'
+  password:
+    required: false
+    description: 'The password of your builder account. Required if `totp` is set.'
   totp:
     required: false
     description: 'The TOTP to use for login. If set, `configVdf` will be ignored.'
@@ -94,6 +97,7 @@ runs:
   image: Dockerfile
   env:
     steam_username: ${{ inputs.username }}
+    steam_password: ${{ inputs.password }}
     steam_totp: ${{ inputs.totp }}
     configVdf: ${{ inputs.configVdf }}
     appId: ${{ inputs.appId }}

--- a/steam_deploy.sh
+++ b/steam_deploy.sh
@@ -138,7 +138,7 @@ echo "#        Test login             #"
 echo "#################################"
 echo ""
 
-steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" +quit;
+steamcmd +set_steam_guard_code "$steam_totp" +login "$steam_username" "$steam_password" +quit;
 
 ret=$?
 if [ $ret -eq 0 ]; then


### PR DESCRIPTION
#### Changes

Unless I am missing something, when using TOTP, a password is required to login. It could be that both steamcmd and this action are missing some details in the documentation, but I can find no way to login to steamcmd with only a username and a TOTP code.

While steamcmd is perfectly fine with accepting the password as part of the username input (separated with a space), the way this action is set up, the second steamcmd invocation where the upload happens would then also use the password, causing steamcmd to error because the password was provided without the TOTP code.

Rather than use the TOTP code there again (as proposed in #86), add the password in the test step (which will cache the credentials), and withhold it from the upload step.

In the configVdf case, the password will be empty, and steamcmd will ignore it, keeping the previous mechanics.

This is a much simpler solution than #86 to the same problem.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated)
- [x] Tests (not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for providing a password when authenticating with a Steam Build Account, required when using a TOTP code.
* **Documentation**
  * Updated documentation to describe the new password configuration parameter and its usage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->